### PR TITLE
Implement greedy name parsing

### DIFF
--- a/vhdl_syntax/src/parser/builder.rs
+++ b/vhdl_syntax/src/parser/builder.rs
@@ -13,6 +13,7 @@ pub(crate) struct NodeBuilder {
     stack: Vec<(usize, GreenNodeData)>,
     rel_offset: usize,
     text_len: usize,
+    token_index: usize,
 }
 
 impl NodeBuilder {
@@ -21,6 +22,7 @@ impl NodeBuilder {
             stack: Vec::default(),
             rel_offset: 0,
             text_len: 0,
+            token_index: 0,
         }
     }
 
@@ -33,6 +35,7 @@ impl NodeBuilder {
         let offset = self.rel_offset;
         self.current().push_token(offset, token);
         self.rel_offset += tok_text_len;
+        self.token_index += 1;
     }
 
     pub fn start_node(&mut self, kind: NodeKind) {
@@ -59,5 +62,9 @@ impl NodeBuilder {
 
     pub fn current_pos(&self) -> usize {
         self.text_len
+    }
+
+    pub fn current_token_index(&self) -> usize {
+        self.token_index
     }
 }

--- a/vhdl_syntax/src/parser/mod.rs
+++ b/vhdl_syntax/src/parser/mod.rs
@@ -28,7 +28,6 @@ pub struct Parser<T: TokenStream> {
     builder: builder::NodeBuilder,
     diagnostics: Vec<diagnostics::ParserDiagnostic>,
     unexpected_eof: bool,
-    token_index: usize,
 }
 
 impl<T: TokenStream> Parser<T> {
@@ -38,12 +37,15 @@ impl<T: TokenStream> Parser<T> {
             builder: builder::NodeBuilder::new(),
             diagnostics: Vec::default(),
             unexpected_eof: false,
-            token_index: 0,
         }
     }
 
     pub fn diagnostics(&self) -> &[diagnostics::ParserDiagnostic] {
         &self.diagnostics
+    }
+
+    pub fn token_index(&self) -> usize {
+        self.builder.current_token_index()
     }
 
     /// Parses a design file and returns the root node.

--- a/vhdl_syntax/src/parser/mod.rs
+++ b/vhdl_syntax/src/parser/mod.rs
@@ -28,6 +28,7 @@ pub struct Parser<T: TokenStream> {
     builder: builder::NodeBuilder,
     diagnostics: Vec<diagnostics::ParserDiagnostic>,
     unexpected_eof: bool,
+    token_index: usize,
 }
 
 impl<T: TokenStream> Parser<T> {
@@ -37,6 +38,7 @@ impl<T: TokenStream> Parser<T> {
             builder: builder::NodeBuilder::new(),
             diagnostics: Vec::default(),
             unexpected_eof: false,
+            token_index: 0,
         }
     }
 

--- a/vhdl_syntax/src/parser/productions/design.rs
+++ b/vhdl_syntax/src/parser/productions/design.rs
@@ -41,7 +41,39 @@ impl<T: TokenStream> Parser<T> {
         self.end_node();
     }
 
-    pub fn context_clause(&mut self) {}
+    pub fn context_clause(&mut self) {
+        loop {
+            match self.tokenizer.peek_next() {
+                Some(tok) => match tok.kind() {
+                    Keyword(Kw::Use) => self.use_clause(),
+                    Keyword(Kw::Library) => self.library_clause(),
+                    Keyword(Kw::Context) => self.context_reference(),
+                    _ => break,
+                },
+                _ => self.eof_err(),
+            }
+        }
+    }
+
+    pub fn library_clause(&mut self) {
+        self.start_node(NodeKind::LibraryClause);
+        self.expect_token(Keyword(Kw::Library));
+        self.identifier_list();
+        self.expect_token(SemiColon);
+        self.end_node();
+    }
+
+    pub fn use_clause(&mut self) {
+        self.start_node(NodeKind::UseClause);
+        self.expect_token(Keyword(Kw::Use));
+        self.name_list();
+        self.expect_token(SemiColon);
+        self.end_node();
+    }
+
+    pub fn context_reference(&mut self) {
+        todo!();
+    }
 }
 
 #[cfg(test)]
@@ -88,6 +120,79 @@ DesignFile
       Keyword(End)
       Keyword(Entity)
       SemiColon
+"
+        );
+    }
+
+    #[test]
+    fn parse_entity_with_context_clause() {
+        let (design, _) = "\
+            library ieee;
+            use ieee.std_logic_1164.all;
+
+            entity my_ent is
+            begin
+            end my_ent;
+        "
+        .parse_syntax(Parser::design_file);
+        assert_eq!(
+            design.test_text(),
+            "\
+DesignFile
+  DesignUnit
+    LibraryClause
+      Keyword(Library)
+      IdentifierList
+        Identifier 'ieee'
+      SemiColon
+    UseClause
+      Keyword(Use)
+      NameList
+        Name
+          Identifier 'ieee'
+          SelectedName
+            Dot
+            Identifier 'std_logic_1164'
+          SelectedName
+            Dot
+            Keyword(All)
+      SemiColon
+    EntityDeclaration
+      Keyword(Entity)
+      Identifier 'my_ent'
+      Keyword(Is)
+      EntityHeader
+      Keyword(Begin)
+      Keyword(End)
+      Identifier 'my_ent'
+      SemiColon
+"
+        );
+    }
+
+    #[test]
+    fn parse_use_clause() {
+        let (node, diag) = "use lib1.lib2.lib3.all;".parse_syntax(Parser::use_clause);
+        assert_eq!(diag.len(), 0);
+
+        assert_eq!(
+            node.test_text(),
+            "\
+UseClause
+  Keyword(Use)
+  NameList
+    Name
+      Identifier 'lib1'
+      SelectedName
+        Dot
+        Identifier 'lib2'
+      SelectedName
+        Dot
+        Identifier 'lib3'
+      SelectedName
+        Dot
+        Keyword(All)
+  SemiColon
 "
         );
     }

--- a/vhdl_syntax/src/parser/productions/expression.rs
+++ b/vhdl_syntax/src/parser/productions/expression.rs
@@ -5,11 +5,29 @@
 // Copyright (c)  2025, Lukas Scheller lukasscheller@icloud.com
 
 use crate::parser::Parser;
+use crate::syntax::node_kind::NodeKind::*;
+use crate::tokens::TokenKind::*;
 use crate::tokens::TokenStream;
 
 impl<T: TokenStream> Parser<T> {
     pub fn expression(&mut self) {
-        // TODO
+        self.start_node(Expression);
+        // TODO: Expecting a simple expression is just a placeholder
+        self.simple_expression();
+        self.end_node();
+    }
+
+    pub fn simple_expression(&mut self) {
+        self.start_node(SimpleExpression);
+        // TODO: Expecting these literals is just a placeholder
+        self.expect_one_of_tokens([CharacterLiteral, StringLiteral, Identifier, AbstractLiteral]);
+        self.end_node();
+    }
+
+    pub fn expression_list(&mut self) {
+        self.start_node(ExpressionList);
+        self.separated_list(Parser::expression, Comma);
+        self.end_node();
     }
 
     pub fn condition(&mut self) {

--- a/vhdl_syntax/src/parser/productions/interface.rs
+++ b/vhdl_syntax/src/parser/productions/interface.rs
@@ -98,7 +98,7 @@ impl<T: TokenStream> Parser<T> {
                 let end_of_element_idx =
                     match parser.lookahead_max_token_index(max_index, [Comma, RightPar]) {
                         Ok((_, idx)) => idx,
-                        Err(idx) => idx,
+                        Err((_, idx)) => idx,
                     };
                 parser.association_element_bounded(end_of_element_idx);
             },

--- a/vhdl_syntax/src/parser/productions/mod.rs
+++ b/vhdl_syntax/src/parser/productions/mod.rs
@@ -16,3 +16,4 @@ mod names;
 mod signature;
 mod statements;
 mod subtype;
+mod scalar_types;

--- a/vhdl_syntax/src/parser/productions/names.rs
+++ b/vhdl_syntax/src/parser/productions/names.rs
@@ -5,9 +5,40 @@
 // Copyright (c)  2025, Lukas Scheller lukasscheller@icloud.com
 
 use crate::parser::Parser;
-use crate::syntax::node_kind::NodeKind::{Label, Name};
+use crate::syntax::node_kind::InternalNodeKind::*;
+use crate::syntax::node_kind::NodeKind::*;
+use crate::tokens::Keyword as Kw;
 use crate::tokens::TokenKind::*;
 use crate::tokens::TokenStream;
+
+fn is_start_of_attribute_name<T: TokenStream>(parser: &mut Parser<T>) -> bool {
+    // Checking for `LeftSquare || Tick` will result in ambiguities with other grammar rules where a signature is possible right after a name.
+    // Those rules can be `alias_declaration` (LRM §6.6.1) and `subprogram_instantiation_declaration` (LRM §4.4).
+    // By checking whether the closing square bracket is followed by a `Tick` this ambiguity is resolved
+    match parser.peek_token() {
+        Some(Tick) => true,
+        Some(LeftSquare) => {
+            let mut idx = 1;
+            let mut bracket_count = 1;
+
+            while bracket_count > 0 {
+                match parser.peek_nth_token(idx) {
+                    Some(LeftSquare) => bracket_count += 1,
+                    Some(RightSquare) => bracket_count -= 1,
+                    Some(_) => {}
+                    None => {
+                        return false;
+                    }
+                }
+
+                idx += 1;
+            }
+
+            parser.next_nth_is(Tick, idx)
+        }
+        Some(_) | None => false,
+    }
+}
 
 impl<T: TokenStream> Parser<T> {
     pub fn designator(&mut self) {
@@ -15,9 +46,20 @@ impl<T: TokenStream> Parser<T> {
     }
 
     pub fn name(&mut self) {
+        // (Based on) LRM §8.1
+        // The LRM grammar rules for names were transformed to avoid left recursion.
+
+        // In contrast to the LRM, this parsing routine is greedy. Meaning, it will consume trailing parenthesized
+        // expressions even if the belong to an outer grammar rule!
         self.start_node(Name);
-        // TODO
-        self.designator();
+
+        if self.next_is(LtLt) {
+            self.external_name();
+        } else {
+            self.designator();
+        }
+
+        self.name_tail();
         self.end_node();
     }
 
@@ -31,5 +73,481 @@ impl<T: TokenStream> Parser<T> {
             self.skip_n(2);
             self.end_node();
         }
+    }
+    pub fn name_list(&mut self) {
+        self.start_node(NameList);
+        self.separated_list(Parser::name, Comma);
+        self.end_node();
+    }
+
+    fn suffix(&mut self) {
+        // LRM §8.3
+        // suffix ::= identifier | string_literal | character_literal | `all` ;
+        self.expect_one_of_tokens([
+            Identifier,
+            StringLiteral,
+            CharacterLiteral,
+            Keyword(Kw::All),
+        ]);
+    }
+
+    fn name_tail(&mut self) {
+        // name             ::= prefix [ name_tail ] ;
+        // name_tail        ::= selected_name | attribute_name | indexed_name | slice_name | function_name ;
+        // selected_name    ::= `.` suffix [ name_tail ] ;
+        // attribute_name   ::= [ signature ] `'` identifier [ `(` expression `)` ] [ name_tail ] ;
+        // function_name    ::= `(` association_list `)` [ name_tail ] ;
+        // indexed_name     ::= `(` expression { `,` expression } `)` [ name_tail ] ;
+        // slice_name       ::= `(` discrete_range `)` [ name_tail ] ;
+
+        if self.next_is(Dot) {
+            self.start_node(SelectedName);
+            self.expect_token(Dot);
+            self.suffix();
+            self.end_node();
+            self.name_tail();
+        } else if self.next_is(LeftPar) {
+            // Try to differentiate between function calls, indexed names and slices as good as possible:
+            // 1. An `association_list` can be uniquely identified by searching for a '=>' inside the parenthesis
+            // 2. When at least a single comma is found, try parse the contents as an expression list
+            // 3. When the `to` or `downto` keyword is found, parse the content as a slice name
+            //
+            // If none of these apply, it can be either a `subtype_indication` or a single `expression`
+
+            if self.lookahead_in_parens([RightArrow]).is_some() {
+                self.start_node(FunctionCallOrIndexedName);
+                self.expect_token(LeftPar);
+                self.association_list();
+                self.expect_token(RightPar);
+                self.end_node();
+            } else if self.lookahead_in_parens([Comma]).is_some() {
+                self.start_node(FunctionCallOrIndexedName);
+                self.expect_token(LeftPar);
+                self.expression_list();
+                self.expect_token(RightPar);
+                self.end_node();
+            } else if self
+                .lookahead_in_parens([Keyword(Kw::To), Keyword(Kw::Downto)])
+                .is_some()
+            {
+                self.start_node(SliceName);
+                self.expect_token(LeftPar);
+                let closing_paren_distance = self.distance_to_closing_paren();
+                self.range(closing_paren_distance.unwrap());
+                self.expect_token(RightPar);
+                self.end_node();
+            } else {
+                // TODO: subtype_indication or expression?
+                self.start_node(Internal(SubtypeIndicationOrExpressionTokens));
+                self.expect_token(LeftPar);
+                match self.distance_to_closing_paren() {
+                    Some(distance) => self.skip_n(distance),
+                    None => {
+                        self.end_node();
+                        self.eof_err();
+                        return;
+                    }
+                }
+                self.expect_token(RightPar);
+                self.end_node();
+            }
+
+            self.name_tail();
+        } else if is_start_of_attribute_name(self) {
+            self.start_node(AttributeName);
+            if self.next_is(LeftSquare) {
+                self.signature();
+            }
+            self.expect_token(Tick);
+
+            // `range` is a keyword, but may appear as a `attribute_name`
+            if !self.opt_identifier() {
+                self.expect_kw(Kw::Range);
+            }
+
+            if self.next_is(LeftPar) {
+                self.start_node(ParenthesizedExpression);
+                self.expect_token(LeftPar);
+                self.expression();
+                self.expect_token(RightPar);
+                self.end_node();
+            }
+            self.end_node();
+            self.name_tail();
+        }
+    }
+
+    pub fn external_name(&mut self) {
+        // LRM §8.7
+        self.start_node(ExternalName);
+        self.expect_token(LtLt);
+
+        self.expect_one_of_tokens([
+            Keyword(Kw::Constant),
+            Keyword(Kw::Signal),
+            Keyword(Kw::Variable),
+        ]);
+        self.external_pathname();
+        self.expect_token(Colon);
+        self.subtype_indication();
+
+        self.expect_token(GtGt);
+        self.end_node();
+    }
+
+    fn external_pathname(&mut self) {
+        // LRM §8.7
+        self.start_node(ExternalPathName);
+        match self.peek_token() {
+            Some(CommAt) => {
+                self.expect_token(CommAt);
+                self.identifier();
+                self.expect_token(Dot);
+                self.identifier();
+                self.expect_token(Dot);
+                self.identifier();
+                while self.opt_token(Dot) {
+                    self.identifier();
+                }
+            }
+            Some(Dot) => {
+                self.expect_token(Dot);
+                self.partial_pathname();
+            }
+            Some(Circ | Identifier) => {
+                while self.opt_token(Circ) {
+                    self.expect_token(Dot);
+                }
+                self.partial_pathname();
+            }
+            Some(_) => {
+                self.expect_tokens_err([CommAt, Dot, Circ, Identifier]);
+            }
+            None => {
+                self.eof_err();
+            }
+        }
+        self.end_node();
+    }
+
+    fn partial_pathname(&mut self) {
+        // LRM §8.7
+        // partial_pathname ::= { identifier [ `(` expression `)` ] `.` } identifier ;
+        self.identifier();
+        loop {
+            if self.next_is(LeftPar) {
+                self.start_node(ParenthesizedExpression);
+                self.expect_token(LeftPar);
+                self.expression();
+                self.expect_token(RightPar);
+                self.end_node();
+                self.expect_token(Dot);
+            } else if !self.opt_token(Dot) {
+                break;
+            }
+            self.identifier();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::{test_utils::check, Parser};
+
+    #[test]
+    fn parse_name() {
+        check(
+            Parser::name,
+            "lib1.fn('a', 1, sig).vector(100 downto 10).all",
+            "\
+Name
+  Identifier 'lib1'
+  SelectedName
+    Dot
+    Identifier 'fn'
+  FunctionCallOrIndexedName
+    LeftPar
+    ExpressionList
+      Expression
+        SimpleExpression
+          CharacterLiteral ''a''
+      Comma
+      Expression
+        SimpleExpression
+          AbstractLiteral
+      Comma
+      Expression
+        SimpleExpression
+          Identifier 'sig'
+    RightPar
+  SelectedName
+    Dot
+    Identifier 'vector'
+  SliceName
+    LeftPar
+    Range
+      SimpleExpression
+        AbstractLiteral
+      Keyword(Downto)
+      SimpleExpression
+        AbstractLiteral
+    RightPar
+  SelectedName
+    Dot
+    Keyword(All)
+",
+        );
+    }
+
+    #[test]
+    fn parse_external_name() {
+        check(
+            Parser::name,
+            "<< constant @lib.pkg.obj : std_ulogic >>",
+            "\
+Name
+  ExternalName
+    LtLt
+    Keyword(Constant)
+    ExternalPathName
+      CommAt
+      Identifier 'lib'
+      Dot
+      Identifier 'pkg'
+      Dot
+      Identifier 'obj'
+    Colon
+    Identifier 'std_ulogic'
+    GtGt
+",
+        );
+
+        check(
+            Parser::name,
+            "<< variable .tb.sig : bit >>",
+            "\
+Name
+  ExternalName
+    LtLt
+    Keyword(Variable)
+    ExternalPathName
+      Dot
+      Identifier 'tb'
+      Dot
+      Identifier 'sig'
+    Colon
+    Identifier 'bit'
+    GtGt
+",
+        );
+
+        check(
+            Parser::name,
+            "<< signal uut.sig : natural >>",
+            "\
+Name
+  ExternalName
+    LtLt
+    Keyword(Signal)
+    ExternalPathName
+      Identifier 'uut'
+      Dot
+      Identifier 'sig'
+    Colon
+    Identifier 'natural'
+    GtGt
+",
+        );
+
+        check(
+            Parser::name,
+            "<< signal ^.up1_signal : real >>",
+            "\
+Name
+  ExternalName
+    LtLt
+    Keyword(Signal)
+    ExternalPathName
+      Circ
+      Dot
+      Identifier 'up1_signal'
+    Colon
+    Identifier 'real'
+    GtGt
+",
+        );
+
+        check(
+            Parser::name,
+            "<<constant^.^.^.^.up4_signal:integer>>",
+            "\
+Name
+  ExternalName
+    LtLt
+    Keyword(Constant)
+    ExternalPathName
+      Circ
+      Dot
+      Circ
+      Dot
+      Circ
+      Dot
+      Circ
+      Dot
+      Identifier 'up4_signal'
+    Colon
+    Identifier 'integer'
+    GtGt
+",
+        );
+
+        check(
+            Parser::name,
+            "<< constant .tb.uut.gen(1).sig : bit >>",
+            "\
+Name
+  ExternalName
+    LtLt
+    Keyword(Constant)
+    ExternalPathName
+      Dot
+      Identifier 'tb'
+      Dot
+      Identifier 'uut'
+      Dot
+      Identifier 'gen'
+      ParenthesizedExpression
+        LeftPar
+        Expression
+          SimpleExpression
+            AbstractLiteral
+        RightPar
+      Dot
+      Identifier 'sig'
+    Colon
+    Identifier 'bit'
+    GtGt
+",
+        );
+    }
+
+    #[test]
+    fn parse_selected_name() {
+        check(
+            Parser::name,
+            "lib.pkg_outer.pkg_inner.obj",
+            "\
+Name
+  Identifier 'lib'
+  SelectedName
+    Dot
+    Identifier 'pkg_outer'
+  SelectedName
+    Dot
+    Identifier 'pkg_inner'
+  SelectedName
+    Dot
+    Identifier 'obj'
+",
+        );
+
+        check(
+            Parser::name,
+            "pkg.all",
+            "\
+Name
+  Identifier 'pkg'
+  SelectedName
+    Dot
+    Keyword(All)
+",
+        );
+    }
+
+    #[test]
+    fn parse_attribute_name() {
+        check(
+            Parser::name,
+            "obj'left",
+            "\
+Name
+  Identifier 'obj'
+  AttributeName
+    Tick
+    Identifier 'left'
+",
+        );
+
+        check(
+            Parser::name,
+            "slv'range",
+            "\
+Name
+  Identifier 'slv'
+  AttributeName
+    Tick
+    Keyword(Range)
+",
+        );
+
+        check(
+            Parser::name,
+            "slv'reverse_range",
+            "\
+Name
+  Identifier 'slv'
+  AttributeName
+    Tick
+    Identifier 'reverse_range'
+",
+        );
+
+        check(
+            Parser::name,
+            "integer'image(obj)",
+            "\
+Name
+  Identifier 'integer'
+  AttributeName
+    Tick
+    Identifier 'image'
+    ParenthesizedExpression
+      LeftPar
+      Expression
+        SimpleExpression
+          Identifier 'obj'
+      RightPar
+",
+        );
+
+        check(
+            Parser::name,
+            "ieee.numeric_std.to_unsigned[natural, natural return unsigned]'simple_name",
+            "\
+Name
+  Identifier 'ieee'
+  SelectedName
+    Dot
+    Identifier 'numeric_std'
+  SelectedName
+    Dot
+    Identifier 'to_unsigned'
+  AttributeName
+    Signature
+      LeftSquare
+      NameList
+        Name
+          Identifier 'natural'
+        Comma
+        Name
+          Identifier 'natural'
+      Keyword(Return)
+      Name
+        Identifier 'unsigned'
+      RightSquare
+    Tick
+    Identifier 'simple_name'
+",
+        );
     }
 }

--- a/vhdl_syntax/src/parser/productions/scalar_types.rs
+++ b/vhdl_syntax/src/parser/productions/scalar_types.rs
@@ -1,0 +1,80 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c)  2024, Lukas Scheller lukasscheller@icloud.com
+/// Parsing of scalar types
+use crate::parser::Parser;
+use crate::syntax::node_kind::NodeKind::*;
+use crate::tokens::{Keyword as Kw, TokenKind::*, TokenStream};
+
+impl<T: TokenStream> Parser<T> {
+    pub fn range(&mut self, max_length: usize) {
+        // LRM §5.2.1
+
+        // `max_length` should give the distance between the current token position and the end of the range to parse.
+        // This way the parser can use a bounded lookahead to distinguish between range expressions (using `to` or `downto`) and attribute names.
+        self.start_node(Range);
+
+        let is_range_expression = self
+            .lookahead_max_distance(max_length, [Keyword(Kw::To), Keyword(Kw::Downto)])
+            .is_some();
+
+        if is_range_expression {
+            self.simple_expression();
+            self.expect_one_of_tokens([Keyword(Kw::To), Keyword(Kw::Downto)]);
+            self.simple_expression();
+        } else {
+            self.name();
+        }
+
+        self.end_node();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::{test_utils::check, Parser};
+
+    #[test]
+    fn parse_range() {
+        check(
+            |parser| Parser::range(parser, usize::MAX),
+            "100 downto 10",
+            "\
+Range
+  SimpleExpression
+    AbstractLiteral
+  Keyword(Downto)
+  SimpleExpression
+    AbstractLiteral
+",
+        );
+
+        check(
+            |parser| Parser::range(parser, usize::MAX),
+            "0 to 0",
+            "\
+Range
+  SimpleExpression
+    AbstractLiteral
+  Keyword(To)
+  SimpleExpression
+    AbstractLiteral
+",
+        );
+
+        check(
+            |parser| Parser::range(parser, usize::MAX),
+            "slv32_t'range",
+            "\
+Range
+  Name
+    Identifier 'slv32_t'
+    AttributeName
+      Tick
+      Keyword(Range)
+",
+        );
+    }
+}

--- a/vhdl_syntax/src/parser/productions/scalar_types.rs
+++ b/vhdl_syntax/src/parser/productions/scalar_types.rs
@@ -28,7 +28,7 @@ impl<T: TokenStream> Parser<T> {
             self.expect_one_of_tokens([Keyword(Kw::To), Keyword(Kw::Downto)]);
             self.simple_expression();
         } else {
-            self.name();
+            self.name_bounded(max_index);
         }
 
         self.end_node();

--- a/vhdl_syntax/src/parser/productions/signature.rs
+++ b/vhdl_syntax/src/parser/productions/signature.rs
@@ -5,10 +5,106 @@
 // Copyright (c)  2025, Lukas Scheller lukasscheller@icloud.com
 
 use crate::parser::Parser;
+use crate::syntax::node_kind::NodeKind::*;
+use crate::tokens::token_kind::Keyword as Kw;
+use crate::tokens::token_kind::TokenKind::*;
 use crate::tokens::TokenStream;
 
 impl<T: TokenStream> Parser<T> {
-    pub fn signature(&self) {
-        unimplemented!()
+    pub fn signature(&mut self) {
+        // LRM §4.5.3
+        // signature ::= `[` [ name { `,` name } ] [ `return` name ] `]`;
+        self.start_node(Signature);
+        self.expect_token(LeftSquare);
+
+        if !self.next_is_one_of([Keyword(Kw::Return), RightSquare]) {
+            self.name_list();
+        }
+
+        if self.opt_token(Keyword(Kw::Return)) {
+            self.name();
+        }
+
+        self.expect_token(RightSquare);
+        self.end_node();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::{test_utils::check, Parser};
+
+    #[test]
+    fn parse_signature() {
+        check(
+            Parser::signature,
+            "[natural, bit return unsigned]",
+            "\
+Signature
+  LeftSquare
+  NameList
+    Name
+      Identifier 'natural'
+    Comma
+    Name
+      Identifier 'bit'
+  Keyword(Return)
+  Name
+    Identifier 'unsigned'
+  RightSquare
+",
+        );
+
+        check(
+            Parser::signature,
+            "[]",
+            "\
+Signature
+  LeftSquare
+  RightSquare
+",
+        );
+
+        check(
+            Parser::signature,
+            "[return ret_t]",
+            "\
+Signature
+  LeftSquare
+  Keyword(Return)
+  Name
+    Identifier 'ret_t'
+  RightSquare
+",
+        );
+
+        check(
+            Parser::signature,
+            "[arg1_t, arg2_t]",
+            "\
+Signature
+  LeftSquare
+  NameList
+    Name
+      Identifier 'arg1_t'
+    Comma
+    Name
+      Identifier 'arg2_t'
+  RightSquare
+",
+        );
+
+        check(
+            Parser::signature,
+            "[arg1_t]",
+            "\
+Signature
+  LeftSquare
+  NameList
+    Name
+      Identifier 'arg1_t'
+  RightSquare
+",
+        );
     }
 }

--- a/vhdl_syntax/src/syntax/node_kind.rs
+++ b/vhdl_syntax/src/syntax/node_kind.rs
@@ -5,12 +5,6 @@
 // Copyright (c)  2025, Lukas Scheller lukasscheller@icloud.com
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
-pub enum InternalNodeKind {
-    ActualPartTokens,
-    SubtypeIndicationOrExpressionTokens,
-}
-
-#[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum NodeKind {
     AttributeDeclaration,
     AttributeSpecification,
@@ -55,7 +49,7 @@ pub enum NodeKind {
     AttributeName,
     FunctionCallOrIndexedName,
     SliceName,
-    Internal(InternalNodeKind),
+    RawTokens,
     NameList,
     AssociationList,
     AssociationElement,

--- a/vhdl_syntax/src/syntax/node_kind.rs
+++ b/vhdl_syntax/src/syntax/node_kind.rs
@@ -5,6 +5,12 @@
 // Copyright (c)  2025, Lukas Scheller lukasscheller@icloud.com
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
+pub enum InternalNodeKind {
+    ActualPartTokens,
+    SubtypeIndicationOrExpressionTokens,
+}
+
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum NodeKind {
     AttributeDeclaration,
     AttributeSpecification,
@@ -24,6 +30,9 @@ pub enum NodeKind {
     DesignUnit,
     DesignFile,
     ContextClause,
+    LibraryClause,
+    UseClause,
+    ContextReference,
     GenericClause,
     PortClause,
     InterfaceList,
@@ -34,5 +43,22 @@ pub enum NodeKind {
     EntityDesignator,
     Label,
     BlockStatement,
-    InterfaceObjectDeclaration, // ...
+    InterfaceObjectDeclaration,
+    ParenthesizedExpression,
+    Expression,
+    SimpleExpression,
+    ExpressionList,
+    Range,
+    SelectedName,
+    ExternalName,
+    ExternalPathName,
+    AttributeName,
+    FunctionCallOrIndexedName,
+    SliceName,
+    Internal(InternalNodeKind),
+    NameList,
+    AssociationList,
+    AssociationElement,
+    FormalPart,
+    ActualPart, // ...
 }


### PR DESCRIPTION
I implemented a first version of name parsing.

As already discussed through Matrix chat, this first implementation cannot fully differentiate some constructs and therefore clumps some tokens together in a generic `Internal(...Tokens)` node. This can be improved upon, but for simple names (especially selected names) it should work just fine.

Also, I added some test to show how the resulting structure may look like. The resulting `SyntaxNode` structure and naming is up for debate.

I implemented some (but definitely not all) of the name related production rules, like `association_list`, `range` and `signature`. 

---

The big TODO is parsing of `expression` and `subtype_indication`. If there is a way to differentiate between these two on the fly, we could maybe avoid doing a second pass to parse `Internal(...)` nodes.